### PR TITLE
Criação das seeders das Tabelas/Quadros e das Tarefas

### DIFF
--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Board extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'name',
         'project_id',
@@ -22,7 +25,7 @@ class Board extends Model
 
     public function project(): BelongsTo
     {
-        return $this->belongsTo(Project::class);
+        return $this->belongsTo(Project::class, 'project_id');
     }
 
     public function tasks(): HasMany

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class Project extends Model
 {
@@ -49,6 +50,11 @@ class Project extends Model
 
     public function boards(): HasMany
     {
-        return $this->hasMany(Board::class);
+        return $this->hasMany(Board::class, 'project_id');
+    }
+
+    public function tasks(): HasManyThrough
+    {
+        return $this->through('boards')->has('tasks');
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -26,7 +26,8 @@ class Project extends Model
         'manager_id',
     ];
 
-    protected function casts(): array {
+    protected function casts(): array
+    {
         return [
             'end_date' => 'date',
             'start_date' => 'date',

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -22,7 +22,8 @@ class Task extends Model
         'assigned_to',
     ];
 
-    public function casts(): array {
+    public function casts(): array
+    {
         return [
             'due_date' => 'datetime',
             'conclusion_date' => 'datetime',
@@ -34,7 +35,8 @@ class Task extends Model
         return $this->belongsTo(Board::class);
     }
 
-    public function assignedTo(): BelongsTo {
+    public function assignedTo(): BelongsTo
+    {
         return $this->belongsTo(User::class, 'assigned_to');
     }
 }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Task extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'title',
         'description',
@@ -19,9 +22,19 @@ class Task extends Model
         'assigned_to',
     ];
 
+    public function casts(): array {
+        return [
+            'due_date' => 'datetime',
+            'conclusion_date' => 'datetime',
+        ];
+    }
 
     public function board(): BelongsTo
     {
         return $this->belongsTo(Board::class);
+    }
+
+    public function assignedTo(): BelongsTo {
+        return $this->belongsTo(User::class, 'assigned_to');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -63,6 +63,10 @@ class User extends Authenticatable
         return $this->hasMany(Project::class, 'manager_id');
     }
 
+    public function tasks(): HasMany {
+        return $this->hasMany(Task::class, 'assigned_to');
+    }
+
     public function projects(): BelongsToMany
     {
         return $this->belongsToMany(

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -63,7 +63,8 @@ class User extends Authenticatable
         return $this->hasMany(Project::class, 'manager_id');
     }
 
-    public function tasks(): HasMany {
+    public function tasks(): HasMany
+    {
         return $this->hasMany(Task::class, 'assigned_to');
     }
 

--- a/database/factories/BoardFactory.php
+++ b/database/factories/BoardFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Board>
+ */
+class BoardFactory extends Factory
+{
+    protected static ?Collection $projects;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        static::$projects ??= Project::all();
+        return [
+            'name' => fake()->word(),
+            'project_id' => static::$projects->random(),
+        ];
+    }
+}

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Board;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Task>
+ */
+class TaskFactory extends Factory
+{
+    protected static ?Collection $boards = null;
+    protected static ?Collection $users = null;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        static::$boards ??= Board::all();
+        static::$users ??= User::all();
+
+        return [
+            'title' => fake()->sentence(5),
+            'description' => fake()->paragraph(),
+            'predicted_hours' => fake()->numberBetween(3, 10),
+            'due_date' => fake()->dateTimeThisMonth(),
+            'conclusion_date' => fake()->optional()->dateTimeThisMonth(),
+            'conclusion_message' => fake()->optional()->sentence(),
+            'status' => fake()
+                ->randomElement([
+                    'PENDENTE',
+                    'APROVADA',
+                    'EM_APROVACAO',
+                    'ATRASADA',
+                    'FINALIZADA_COM_ATRASO'
+                ]),
+            'board_id' => static::$boards->random(),
+            'assigned_to' => static::$users->random(),
+        ];
+    }
+}

--- a/database/migrations/2025_11_23_214102_create_tasks_table.php
+++ b/database/migrations/2025_11_23_214102_create_tasks_table.php
@@ -22,8 +22,8 @@ return new class extends Migration
 
             $table->enum('status', ['PENDENTE', 'APROVADA', 'EM_APROVACAO', 'ATRASADA', 'FINALIZADA_COM_ATRASO'])->default('pendente');
 
-            $table->foreignId('board_id')->constrained('boards');
-            $table->foreignId('assigned_to')->constrained('users');
+            $table->foreignId('board_id')->nullable()->constrained('boards');
+            $table->foreignId('assigned_to')->nullable()->constrained('users');
 
             $table->timestamps();
         });

--- a/database/migrations/2025_12_24_033249_fix_boards_table_column_name.php
+++ b/database/migrations/2025_12_24_033249_fix_boards_table_column_name.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('boards', function (Blueprint $table) {
+            $table->renameColumn('nome', 'name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('boards', function (Blueprint $table) {
+            $table->renameColumn('name', 'nome');
+        });
+    }
+};

--- a/database/migrations/2025_12_24_033751_add_timestamps_boards_table.php
+++ b/database/migrations/2025_12_24_033751_add_timestamps_boards_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('boards', function (Blueprint $table) {
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('boards', function (Blueprint $table) {
+            $table->dropColumn(['updated_at', 'created_at']);
+        });
+    }
+};

--- a/database/seeders/ProjectSeeder.php
+++ b/database/seeders/ProjectSeeder.php
@@ -2,7 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Models\Board;
 use App\Models\Project;
+use App\Models\Task;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Eloquent\Collection;
@@ -21,10 +23,36 @@ class ProjectSeeder extends Seeder
         Project::factory(3)
             ->for(User::find(1), 'manager')
             ->hasAttached(static::$users->random(5), [], 'collaborators')
-            ->create();
+            ->has(
+                Board::factory(3)
+                    ->has(Task::factory(5), 'tasks'),
+                'boards'
+            )
+            ->create()
+            ->each(function (Project $project) {
+                $collaboratorIds = $project->collaborators->pluck('id');
+                $project->boards->each(function (Board $board) use ($collaboratorIds) {
+                    $board->tasks->each(function (Task $task) use ($collaboratorIds) {
+                        $task->update(['assigned_to' => $collaboratorIds->random()]);
+                    });
+                });
+            });
 
         Project::factory(10)
             ->hasAttached(static::$users->random(5), [], 'collaborators')
-            ->create();
+            ->has(
+                Board::factory(3)
+                    ->has(Task::factory(5), 'tasks'),
+                'boards'
+            )
+            ->create()
+            ->each(function (Project $project) {
+                $collaboratorIds = $project->collaborators->pluck('id');
+                $project->boards->each(function (Board $board) use ($collaboratorIds) {
+                    $board->tasks->each(function (Task $task) use ($collaboratorIds) {
+                        $task->update(['assigned_to' => $collaboratorIds->random()]);
+                    });
+                });
+            });
     }
 }


### PR DESCRIPTION
- Agora os quadros/tabelas e as tarefas serão criadas automaticamente por projeto.
- Cada projeto terá respectivamente 3 quadros e 15 tarefas (5 tarefas por quadro)
- Todas as tarefas também possuem somente os usuários que participam do mesmo projeto

> Obs: A ligação das tarefas com os usuários no momento está quase uma gambiarra. Talvez seja necessário dar uma olhada para uma possível melhora